### PR TITLE
[REEF-2059] Identify 'connection refuesed' error correctly

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
@@ -303,7 +303,7 @@ public final class NettyMessagingTransport implements Transport {
         }
         break;
       } catch (final Exception e) {
-        if (e.getClass().getSimpleName().compareTo("ConnectException") == 0) {
+        if (e instanceof ConnectException) {
           LOG.log(Level.WARNING, "Connection refused. Retry {0} of {1}",
               new Object[]{i + 1, this.numberOfTries});
           synchronized (flag) {


### PR DESCRIPTION
- Fix error handling in NettyMessagingTransport so that exceptions
  extending java.net.ConnectionException are regarded as 'connection
  refuesed' error.

JIRA:
  [REEF-2059](https://issues.apache.org/jira/browse/REEF-2059)